### PR TITLE
Fix Async always erroring out

### DIFF
--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -688,6 +688,10 @@
                   },
                   "description": "Data"
                 },
+                "StatementHandle": {
+                  "type": "string",
+                  "description": "StatementHandle"
+                },
                 "Metadata": {
                   "type": "object",
                   "properties": {
@@ -716,10 +720,6 @@
                       "type": "string",
                       "description": "SqlState"
                     },
-                    "StatementHandle": {
-                      "type": "string",
-                      "description": "StatementHandle"
-                    },
                     "CreatedOn": {
                       "type": "string",
                       "description": "CreatedOn"
@@ -735,31 +735,43 @@
             "schema": {
               "type": "object",
               "properties": {
-                "statementHandle": {
-                  "type": "string",
-                  "example": "GUID value"
-                },
-                "code": {
-                  "type": "string",
-                  "example": "000123"
-                },
-                "sqlState": {
-                  "type": "string",
-                  "example": "42601"
-                },
-                "message": {
-                  "type": "string",
-                  "example": "successfully executed"
-                },
-                "createdOn": {
-                  "type": "integer",
-                  "format": "int32",
-                  "description": "Timestamp that specifies when the statement execution started. The timestamp is expressed in milliseconds since the epoch",
-                  "example": 1597090533987
-                },
-                "statementStatusUrl": {
-                  "type": "string",
-                  "example": "/api/v2/statements/GUID value"
+                "Metadata": {
+                  "type": "object",
+                  "properties": {
+                    "Rows": {
+                      "type": "integer",
+                      "format": "int32",
+                      "description": "Rows"
+                    },
+                    "Format": {
+                      "type": "string",
+                      "description": "Format"
+                    },
+                    "Code": {
+                      "type": "string",
+                      "description": "Code"
+                    },
+                    "StatementStatusUrl": {
+                      "type": "string",
+                      "description": "StatementStatusUrl"
+                    },
+                    "RequestId": {
+                      "type": "string",
+                      "description": "RequestId"
+                    },
+                    "SqlState": {
+                      "type": "string",
+                      "description": "SqlState"
+                    },
+                    "CreatedOn": {
+                      "type": "string",
+                      "description": "CreatedOn"
+                    },
+                    "Message": {
+                      "type": "string",
+                      "description": "Message"
+                    }
+                  }
                 }
               }
             }

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -975,10 +975,9 @@
           {
             "name": "body",
             "in": "body",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "object",
-              "required": ["DataSchema"],
               "properties": {
                 "DataSchema": {
                   "type": "array",


### PR DESCRIPTION
- Async was still trying to convert response which was bombing.
- Also found out during testing Async that you then need to issue a GetResults for partition zero since ExecSql Async does not return data. So since this is the 0 partition, you don't already have the DataSchema so you can't pass it in. Because you don't pass anything in, you end up with an empty request body. Which then when the convert method gets called, it tries parsing an empty body as json, which breaks.
- Update the response schema for ExecSql Async to match the schema of ExecSql Sync since the PowerApps UI does not seem to be able to deal with varying response formats when mapping fields using the Dynamic Content helper.