### PR TITLE
SPC-36: Handle unexpected async responses better

### DIFF
--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -451,7 +451,7 @@ public class Script : ScriptBase
 
     public class PerformanceData
     {
-        public DateTimeOffset BeingFetch {get;set;}
+        public DateTimeOffset BeginFetch {get;set;}
         public DateTimeOffset EndFetch {get;set;}
         public int FetchDurationSeconds {get;set;}
 

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -82,14 +82,14 @@ public class Script : ScriptBase
             HttpResponseMessage response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             if (response.IsSuccessStatusCode)
             {
-                if(IsFullResponseWithData())
+                if(IsFullResponseWithData(response))
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var converted = ConvertToObjects_FullReponseWithData(responseContent, Context.OperationId, originalContent);
 
                     return converted.GetAsResponse();
                 }
-                else if(IsAsyncResponse())
+                else if(IsAsyncResponse(response))
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var converted = ConvertToObjects_AsyncResponse(responseContent, Context.OperationId);
@@ -154,16 +154,16 @@ public class Script : ScriptBase
         return (nullable == "true");
     }
 
-    private bool IsFullResponseWithData()
+    private bool IsFullResponseWithData(HttpResponseMessage response)
     {
-        return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS)
-            && GetQueryStringParam(QueryString_Async) != "true";
+        return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS) &&
+            response.StatusCode == HttpStatusCode.OK;
     }
 
-    private bool IsAsyncResponse()
+    private bool IsAsyncResponse(HttpResponseMessage response)
     {
-        return Context.OperationId == OP_EXECUTE_SQL &&
-            GetQueryStringParam(QueryString_Async) == "true";
+        return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS) &&
+            response.StatusCode == HttpStatusCode.Accepted;
     }
 
     private ConvertObjectResult ConvertToObjects_AsyncResponse(string content, string operationId)
@@ -447,6 +447,17 @@ public class Script : ScriptBase
                 return createErrorResponse(ErrorStatusCode, ErrorMessage);
             }
         }
+    }
+
+    public class PerformanceData
+    {
+        public DateTimeOffset BeingFetch {get;set;}
+        public DateTimeOffset EndFetch {get;set;}
+        public int FetchDurationSeconds {get;set;}
+
+        public DateTimeOffset? BeginConvert {get;set;}
+        public DateTimeOffset? EndConvert {get;set;}
+        public int? ConvertDurationSeconds {get;set;}
     }
 
     public class SnowflakeResponseMetadata


### PR DESCRIPTION
The previous Async fixes assumed that the shape of the response would always match what was requested. That is not always true. If you make a Sync request, but it runs too long snowflake may choose to return an Async response to check back later for the results. Also if you run GetResults and the data isn't ready yet, it needs to be able to handle yet another Async status response without data.