### PR TITLE
SPC-39: MULTI_STATEMENT_COUNT parameter was being ignored

### DIFF
--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -153,6 +153,10 @@
                       "type": "string",
                       "description": "StatementHandle"
                     },
+                    "StatementHandles": {
+                      "type": "array",
+                      "description": "StatementHandles from executing multiple statements"
+                    },
                     "CreatedOn": {
                       "type": "string",
                       "description": "CreatedOn"

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -541,7 +541,7 @@
                       "example": "YYYY-MM-DDTHH24:MI:SS.FF6 TZHTZM",
                       "x-ms-summary": "timestamp tz output format"
                     },
-                    "multi_statement_count": {
+                    "MULTI_STATEMENT_COUNT": {
                       "description": "Number of statements to execute when using multi-statement capability. 0 implies variable number of statements. Negative numbers are not allowed.",
                       "type": "integer",
                       "example": 4,

--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -727,6 +727,10 @@
                     "CreatedOn": {
                       "type": "string",
                       "description": "CreatedOn"
+                    },
+                    "StatementHandles": {
+                      "type": "array",
+                      "description": "StatementHandles from executing multiple statements"
                     }
                   },
                   "description": "Metadata"

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -339,6 +339,7 @@ public class Script : ScriptBase
                     RequestId = contentAsJson["requestId"].ToString(),
                     SqlState = contentAsJson["sqlState"].ToString(),
                     StatementHandle = contentAsJson["statementHandle"].ToString(),
+                    StatementHandles = contentAsJson["statementHandles"]?.Select(x => x.ToString()).ToArray(),
                     CreatedOn = ConvertToUTC(contentAsJson["createdOn"].ToString(), TimeInterval.Milliseconds)
                 };
 
@@ -465,7 +466,10 @@ public class Script : ScriptBase
 
         public string? StatementHandle { get; set; }
 
+        public string[]? StatementHandles { get; set; }
+
         public string? CreatedOn { get; set; }
+
         public string? Message { get; set; }
     }
 

--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -82,14 +82,14 @@ public class Script : ScriptBase
             HttpResponseMessage response = await Context.SendAsync(Context.Request, CancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             if (response.IsSuccessStatusCode)
             {
-                if(IsFullResponseWithData(response))
+                if(IsFullResponseWithData())
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var converted = ConvertToObjects_FullReponseWithData(responseContent, Context.OperationId, originalContent);
 
                     return converted.GetAsResponse();
                 }
-                else if(IsAsyncResponse(response))
+                else if(IsAsyncResponse())
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var converted = ConvertToObjects_AsyncResponse(responseContent, Context.OperationId);
@@ -154,16 +154,16 @@ public class Script : ScriptBase
         return (nullable == "true");
     }
 
-    private bool IsFullResponseWithData(HttpResponseMessage response)
+    private bool IsFullResponseWithData()
     {
         return (Context.OperationId == OP_EXECUTE_SQL || Context.OperationId == OP_GET_RESULTS)
-            && response.StatusCode == HttpStatusCode.OK;
+            && GetQueryStringParam(QueryString_Async) != "true";
     }
 
-    private bool IsAsyncResponse(HttpResponseMessage response)
+    private bool IsAsyncResponse()
     {
-        return Context.OperationId == OP_EXECUTE_SQL 
-            && response.StatusCode == HttpStatusCode.Accepted;
+        return Context.OperationId == OP_EXECUTE_SQL &&
+            GetQueryStringParam(QueryString_Async) == "true";
     }
 
     private ConvertObjectResult ConvertToObjects_AsyncResponse(string content, string operationId)


### PR DESCRIPTION
Changing param definition to match the case specified in the Snowflake API docs seems to have fixed the parameter being ignored.

NOTE: Multi-statement queries must be fully qualified with {Warehouse}.{Schema}.{Table/View/Func} because it seems to ignore the Warehouse and Schema context parameters in the request payload, that otherwise work fine for single statement requests.