### PR TITLE
GetResults schema

### DIFF
--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -651,45 +651,7 @@
                 },
                 "Data": {
                   "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "ID": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "ID"
-                      },
-                      "FIRSTNAME": {
-                        "type": "string",
-                        "description": "FIRSTNAME"
-                      },
-                      "LASTNAME": {
-                        "type": "string",
-                        "description": "LASTNAME"
-                      },
-                      "GENDER": {
-                        "type": "string",
-                        "description": "GENDER"
-                      },
-                      "AGE": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "AGE"
-                      },
-                      "EMAIL": {
-                        "type": "string",
-                        "description": "EMAIL"
-                      },
-                      "PHONE": {
-                        "type": "string",
-                        "description": "PHONE"
-                      },
-                      "EDUCATION": {
-                        "type": "string",
-                        "description": "EDUCATION"
-                      }
-                    }
-                  },
+                  "items": {},
                   "description": "Data"
                 },
                 "StatementHandle": {


### PR DESCRIPTION
Innacurate schema was causing compilation issues in the power apps. Better to leave it as a untyped object since the schema is dynamic.