### PR TITLE
openapi spec validation errors

### DIFF
--- a/certified-connectors/Snowflake v2/apiDefinition.swagger.json
+++ b/certified-connectors/Snowflake v2/apiDefinition.swagger.json
@@ -155,6 +155,9 @@
                     },
                     "StatementHandles": {
                       "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "StatementHandles from executing multiple statements"
                     },
                     "CreatedOn": {
@@ -692,6 +695,9 @@
                     },
                     "StatementHandles": {
                       "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "StatementHandles from executing multiple statements"
                     }
                   },


### PR DESCRIPTION
- Add types to untyped params that were throwing errors upon validation of the swagger json.