### PR TITLE
feat: Unify return types for all assertions

### DIFF
--- a/custom-connectors/ppUnit/README.md
+++ b/custom-connectors/ppUnit/README.md
@@ -155,3 +155,8 @@ All assertions will return an status code and a status message for all pass or f
 * `Assert True`: Asserts that a given condition is true.
 
 * `Assert False`: Asserts that a given condition is false.
+
+## Contributors
+
+* Joe Brinkman <joe.brinkman@improving.com>
+* Tobin Chee <tobin.chee@improving.com>

--- a/custom-connectors/ppUnit/apiDefinition.swagger.json
+++ b/custom-connectors/ppUnit/apiDefinition.swagger.json
@@ -66,22 +66,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "Passed": {
-                  "type": "boolean",
-                  "description": "Did the assertion pass all conditions",
-                  "title": "Passed"
-                },
-                "ErrorMessages": {
-                  "type": "array",
-                  "description": "List of all errors encountered.",
-                  "title": "ErrorMessages",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
+              "$ref": "#/definitions/Status"
             }
           },
           "default": {
@@ -203,9 +188,9 @@
       "type": "object",
       "properties": {
         "statusCode": {
-          "type": "number",
+          "type": "integer",
           "description": "The result of the assertion.",
-          "title": "result"
+          "title": "statusCode"
         },
         "statusMessage": {
           "type": "string",
@@ -289,10 +274,10 @@
             "title": "expected"
           },
           "failureCode": {
-            "type": "number",
+            "type": "integer",
             "description": "The code to return if the assertion fails.",
             "title": "failureCode",
-            "default": 400,
+            "default": 417,
             "x-ms-visibility": "advanced"
           },
           "failureMessage": {
@@ -318,7 +303,7 @@
             "title": "actual"
           },
           "failureCode": {
-            "type": "number",
+            "type": "integer",
             "description": "The code to return if the assertion fails.",
             "title": "failureCode",
             "default": 400,


### PR DESCRIPTION
This update unifies all assertions to return the same object. This allows similar logic to be used in every flow for validating behavior.  Every assertion returns an object with a `statusCode` and a `statusMessage`.  The AssertAll assertion can capture a separate message for every defined assertion. These messages are joined with a NewLine separator before being returned which eliminates the need for custom PowerFx logic for handling these messages.  Now all assertions will follow the same usage pattern.


