### PR TITLE
SPC-59: fix time formatting bug

### DIFF
--- a/certified-connectors/Snowflake v2/script.csx
+++ b/certified-connectors/Snowflake v2/script.csx
@@ -314,16 +314,8 @@ public class Script : ScriptBase
                                 newRow.Add(new JProperty(name.ToString(), JArray.Parse(row[i].ToString())));
                                 break;
                             default:
-                                if (type.ToString().IndexOf(Snowflake_Type_Time) >= 0)
-                                {
-                                    var utcTime = ConvertToUTC(row[i].ToString());
-                                    newRow.Add(new JProperty(name.ToString(), utcTime));
-                                }
-                                else
-                                {
-                                    var val = row[i];
-                                    newRow.Add(new JProperty(name.ToString(), val));
-                                }
+                                // every other type gets passed thru directly as a string.
+                                newRow.Add(new JProperty(name.ToString(), row[i]));
                                 break;
                         }
                     }


### PR DESCRIPTION
Just remove the formatting. All the other date types aren't handled in the connector. Also, snowflake has extensive support for date/time localization and formatting.